### PR TITLE
Time Travel for Javascript Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,24 +49,32 @@ Since you've changed your browser class, you've gained access to two new Dusk br
 - `travelTo($time)` - travel through time, using a `Illuminate/Support/Carbon` instance as the time input.
 - `travelBack()` - return to the current time.
 
-**Note**: As the package uses cookies to deliver the modified time to the browser, only the next requests will use the changed time, the current page won't have the date modified. For logging in, this means you may need to change the time and _then_ load the login page.
+The traveled time is delivered via a cookie, which has two consequences:
+1. The browser must already be on a page of your app when you call `travelTo()` or `travelBack()`, so `visit()` something first or you'll get an `invalid cookie domain` error.
+2. The time change (both server-side and browser-side JavaScript) only applies from the **next** page load; the current page is unaffected.
 
 For example:
 
 ```php
 $this->browse(function ($browser) {
-
-    // The home page will show today's date
-    $browser->visit("home")
-        ->travelTo(Carbon::tomorrow());
+    
+    $browser->visit('/')
+        // (1) Visit home, (2) Travel to tomorrow
+        ->visit("home")
+        ->travelTo(Carbon::tomorrow())
+        // The home page will show today's date (we have NOT reloaded the page)
+        ->assertSee(Carbon::today()->format('Y-m-d'));
 });
 ```
 ```php
 $this->browse(function ($browser) {
 
-    // The home page will show tomorrow's date
-    $browser->travelTo(Carbon::tomorrow())
-        ->visit("home");
+    $browser->visit('/')
+        // (1) Travel to tomorrow, (2) Visit home
+        ->travelTo(Carbon::tomorrow())
+        ->visit("home")
+        // The home page will show tomorrow's date (we have reloaded the page)
+        ->assertSee(Carbon::tomorrow()-format('Y-m-d'));
 });
 ```
 
@@ -78,7 +86,8 @@ Other usage examples:
 $this->browse(function ($browser) {
 
     // Do something in yesterdays date and expect to see that it occurred on that date
-    $browser->travelTo(Carbon::yesterday())->visit($itemDetailsPage)
+    $browser->visit('/')
+        ->travelTo(Carbon::yesterday())->visit($itemDetailsPage)
         ->doStuffInYesterdaysDate()
         ->travelBack()->visit($itemDetailsPage)
         ->assertSee(Carbon::yesterday());
@@ -98,8 +107,36 @@ $this->browse(function ($browser) {
 
 After you've recreated the instance, or manually reset with `travelBack()`, the server will revert to the normal date.
 
+## Browser-side (JavaScript) time travel
+
+In addition to faking server-side time, `travelTo()` also fakes time for JavaScript running in the browser. `new Date()`, `Date.now()` and plain `Date()` calls in page scripts will return the traveled time. This works by registering a small `Date` shim through the Chrome DevTools Protocol (`Page.addScriptToEvaluateOnNewDocument`), so it:
+
+- takes effect on the **next page load** — consistent with when the server-side time changes,
+- survives navigations, and runs **before** any page script on every new document,
+- is removed again by `travelBack()`, also taking effect on the next page load.
+
+Note that each page load starts exactly at the traveled instant and then ticks forward naturally (time is shifted, not frozen — freezing would break polling and animation code).
+
+Since the server re-freezes to the traveled time at the start of each request, browser and server agree at page-load time and the browser then drifts forward by the age of the page.
+
+To fake only server-side time, pass `false` as the second argument:
+
+```php
+// All PHP versions:
+$browser->visit('/')->travelTo(Carbon::tomorrow(), false);
+
+// Or if you'd like to use named parameters (PHP 8.0+):
+$browser->visit('/')->travelTo(Carbon::tomorrow(), javascript: false);
+```
+
+Limitations:
+
+- Requires Chrome/Chromium (the standard Dusk setup). On other drivers, or if the DevTools command is unavailable, browser-side faking silently degrades and server-side faking continues to work as before.
+- Only the zero-argument functions are shifted. Explicit constructions like `new Date(2020, 0, 1)`, `Date.parse()` and `Date.UTC()` behave natively (as you'd expect).
+- `performance.now()` and Web Workers are not faked.
+
 ## Testing
-A test case is included, but since it's a Dusk extension, the tests are run on a Laravel instance having Dusk installed. You can test the plugin the same way the `.github/workflows/run-tests.yml` workflow does.
+A test case is included in this respository, but since it's a Dusk extension the tests are run on a Laravel instance having Dusk installed. You can test the plugin the same way the `.github/workflows/run-tests.yml` workflow does.
 
 ## Security Vulnerabilities
 

--- a/resources/js/date-shim.js
+++ b/resources/js/date-shim.js
@@ -1,0 +1,81 @@
+(function () {
+    'use strict';
+
+    var globalScope;
+
+    if (typeof globalThis !== 'undefined') {
+        globalScope = globalThis;
+    } else {
+        globalScope = window;
+    }
+
+    var previousState = globalScope.__duskTimeTravel;
+
+    // When the shim is already installed, reuse the original native Date.
+    var NativeDate;
+
+    if (previousState) {
+        NativeDate = previousState.native;
+    } else {
+        NativeDate = globalScope.Date;
+    }
+
+    var offset = __DUSK_TARGET_MS__ - NativeDate.now();
+
+    // Travelling again only needs the offset retargeted.
+    if (previousState) {
+        previousState.offset = offset;
+
+        return;
+    }
+
+    var state = {
+        native: NativeDate,
+        offset: offset
+    };
+
+    function fakeNow() {
+        return NativeDate.now() + state.offset;
+    }
+
+    function FakeDate(value) {
+        // Date() called as a plain function returns the date string for "now".
+        if (! (this instanceof FakeDate)) {
+            var current = new NativeDate(fakeNow());
+
+            return current.toString();
+        }
+
+        // new Date() with no arguments returns the traveled time.
+        if (arguments.length === 0) {
+            return new NativeDate(fakeNow());
+        }
+
+        // A single timestamp or date string argument is not shifted.
+        if (arguments.length === 1) {
+            return new NativeDate(value);
+        }
+
+        // Explicit date components are not shifted either.
+        var boundArguments = [null].concat(Array.prototype.slice.call(arguments));
+        var BoundDate = Function.prototype.bind.apply(NativeDate, boundArguments);
+
+        return new BoundDate();
+    }
+
+    // Returning a native instance from the constructor keeps `instanceof Date`
+    // and every prototype method working natively.
+    FakeDate.prototype = NativeDate.prototype;
+    FakeDate.now = fakeNow;
+    FakeDate.parse = NativeDate.parse;
+    FakeDate.UTC = NativeDate.UTC;
+
+    try {
+        Object.setPrototypeOf(FakeDate, NativeDate);
+    } catch (error) {
+        // Older engines without setPrototypeOf: static inheritance is cosmetic.
+    }
+
+    globalScope.Date = FakeDate;
+    globalScope.__duskTimeTravel = state;
+})();

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -2,22 +2,39 @@
 
 namespace Paksuco\DuskTimeTravel;
 
+use Exception;
 use Illuminate\Support\Carbon;
 use Laravel\Dusk\Browser as DuskBrowser;
 
 class Browser extends DuskBrowser
 {
     /**
+     * CDP identifier of the Date shim registered via
+     * Page.addScriptToEvaluateOnNewDocument, if any.
+     *
+     * Dusk reuses Browser instances across tests in a class, so the
+     * identifier lives on the instance and is replaced on re-travel.
+     *
+     * @var string|null
+     */
+    protected $timeTravelScriptIdentifier = null;
+
+    /**
      * Travels to the specified time
      *
-     * @param   Carbon  $time  The time to mimic on the browser
+     * @param   Carbon  $time       The time to mimic on the browser
+     * @param   bool    $javascript Whether to also fake JavaScript Date in the browser
      *
-     * @return  Browser        The browser instance to support chaining
+     * @return  Browser             The browser instance to support chaining
      */
-    public function travelTo(Carbon $time)
+    public function travelTo(Carbon $time, $javascript = true)
     {
-        return tap($this, function (DuskBrowser $browser) use ($time) {
+        return tap($this, function (DuskBrowser $browser) use ($time, $javascript) {
             $browser->plainCookie("dusk-skip-time", $time->toIso8601String());
+
+            if ($javascript) {
+                $this->fakeBrowserTime($time);
+            }
         });
     }
 
@@ -30,6 +47,88 @@ class Browser extends DuskBrowser
     {
         return tap($this, function (DuskBrowser $browser) {
             $browser->deleteCookie("dusk-skip-time");
+            $this->restoreBrowserTime();
         });
+    }
+
+    /**
+     * Overrides the browser's JavaScript Date so pages see the traveled time.
+     *
+     * The shim is registered to run before any page script on every new
+     * document. The currently loaded page is deliberately left untouched so
+     * browser time changes on the next request, consistent with when the
+     * server-side time changes.
+     *
+     * @param   Carbon  $time  The time the browser should believe it is
+     *
+     * @return  void
+     */
+    protected function fakeBrowserTime(Carbon $time)
+    {
+        $this->removeNewDocumentScript();
+
+        $result = $this->sendDevToolsCommand('Page.addScriptToEvaluateOnNewDocument', [
+            'source' => BrowserTimeFaker::shimSource($time),
+        ]);
+
+        if (is_array($result) && isset($result['identifier'])) {
+            $this->timeTravelScriptIdentifier = $result['identifier'];
+        }
+    }
+
+    /**
+     * Stops faking the browser's Date from the next page load onwards.
+     *
+     * @return  void
+     */
+    protected function restoreBrowserTime()
+    {
+        $this->removeNewDocumentScript();
+    }
+
+    /**
+     * Unregisters the previously injected new-document script, if any.
+     *
+     * @return  void
+     */
+    protected function removeNewDocumentScript()
+    {
+        if ($this->timeTravelScriptIdentifier === null) {
+            return;
+        }
+
+        $this->sendDevToolsCommand('Page.removeScriptToEvaluateOnNewDocument', [
+            'identifier' => $this->timeTravelScriptIdentifier,
+        ]);
+
+        $this->timeTravelScriptIdentifier = null;
+    }
+
+    /**
+     * Sends a Chrome DevTools Protocol command through the WebDriver session.
+     *
+     * @param   string  $command  The CDP command name
+     * @param   array   $params   The CDP command parameters
+     *
+     * @return  mixed|null        The CDP result, or null when CDP is
+     *                            unavailable (non-Chrome driver or old
+     *                            chromedriver) — browser-side time faking
+     *                            silently degrades to server-side only
+     */
+    protected function sendDevToolsCommand($command, array $params)
+    {
+        if (! method_exists($this->driver, 'executeCustomCommand')) {
+            return null;
+        }
+
+        try {
+            return $this->driver->executeCustomCommand(
+                '/session/:sessionId/goog/cdp/execute',
+                'POST',
+                ['cmd' => $command, 'params' => (object) $params]
+            );
+        } catch (Exception $e) {
+            return null;
+        }
     }
 }

--- a/src/BrowserTimeFaker.php
+++ b/src/BrowserTimeFaker.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Paksuco\DuskTimeTravel;
+
+use Illuminate\Support\Carbon;
+
+class BrowserTimeFaker
+{
+    /**
+     * Builds the JavaScript Date shim targeting the given time.
+     *
+     * @param   Carbon  $time  The time the browser should believe it is
+     *
+     * @return  string         The JavaScript source to inject
+     */
+    public static function shimSource(Carbon $time)
+    {
+        $source = file_get_contents(__DIR__ . '/../resources/js/date-shim.js');
+
+        return str_replace('__DUSK_TARGET_MS__', (string) static::targetMilliseconds($time), $source);
+    }
+
+    /**
+     * Converts a Carbon instance to an epoch timestamp in milliseconds.
+     *
+     * @param   Carbon  $time  The time to convert
+     *
+     * @return  int            Milliseconds since the Unix epoch
+     */
+    public static function targetMilliseconds(Carbon $time)
+    {
+        return $time->getTimestamp() * 1000 + (int) $time->format('v');
+    }
+}

--- a/tests/Browser/BrowserTimeTest.php
+++ b/tests/Browser/BrowserTimeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Paksuco\DuskTimeTravel\Tests\Browser;
+
+use Illuminate\Support\Carbon;
+use Paksuco\DuskTimeTravel\Browser;
+use Paksuco\DuskTimeTravel\Tests\DuskTestCase;
+
+class BrowserTimeTest extends DuskTestCase
+{
+    public function testJavaScriptSeesTraveledTimeAfterVisit()
+    {
+        $target = Carbon::parse('2021-03-04 05:06:07');
+
+        $this->browse(function (Browser $browser) use ($target) {
+            // travelTo() sets a cookie, which the browser only accepts while a
+            // page of the app is open — a fresh session starts on about:blank,
+            // so every test visits a page before its first travelTo().
+            $browser->visit('/js-time')
+                ->travelTo($target)->visit('/js-time');
+
+            $this->assertCarbonWithin($target, $browser->text('#js-iso'));
+
+            $jsNowSeconds = (int) round(((float) $browser->text('#js-now')) / 1000);
+            $this->assertLessThan(15, abs($jsNowSeconds - $target->getTimestamp()));
+
+            $browser->travelBack();
+        });
+    }
+
+    public function testServerAndBrowserAgree()
+    {
+        $target = Carbon::parse('2021-03-04 05:06:07');
+
+        $this->browse(function (Browser $browser) use ($target) {
+            $browser->visit('/js-time')
+                ->travelTo($target)->visit('/js-time');
+
+            $serverTime = Carbon::parse($browser->text('#server-time'));
+            $this->assertCarbonWithin($serverTime, $browser->text('#js-iso'));
+
+            $browser->travelBack();
+        });
+    }
+
+    public function testExplicitDateArgumentsUnaffected()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/js-time')
+                ->travelTo(Carbon::parse('2031-06-07 08:09:10'))->visit('/js-time');
+
+            $this->assertStringContainsString('2020-01-0', $browser->text('#js-explicit'));
+
+            $year = $browser->script('return new Date(2020, 0, 1).getFullYear();')[0];
+            $this->assertSame(2020, (int) $year);
+
+            $browser->travelBack();
+        });
+    }
+
+    public function testCurrentPageKeepsRealTimeUntilNextNavigation()
+    {
+        $target = Carbon::parse('2021-03-04 05:06:07');
+
+        $this->browse(function (Browser $browser) use ($target) {
+            $browser->visit('/js-time')->travelTo($target);
+
+            // The current page is unaffected, consistent with server-side time.
+            $jsNowSeconds = (int) round(((float) $browser->script('return Date.now();')[0]) / 1000);
+            $this->assertLessThan(15, abs($jsNowSeconds - Carbon::now()->getTimestamp()));
+
+            // The next page load uses the traveled time.
+            $browser->visit('/js-time');
+            $this->assertCarbonWithin($target, $browser->text('#js-iso'));
+
+            $browser->travelBack();
+        });
+    }
+
+    public function testTravelBackRestoresBrowserTime()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/js-time')
+                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js-time');
+
+            $browser->travelBack()->visit('/js-time');
+
+            $this->assertCarbonWithin(Carbon::now(), $browser->text('#js-iso'));
+            $this->assertSame('undefined', $browser->script('return typeof window.__duskTimeTravel;')[0]);
+        });
+    }
+
+    public function testDateFunctionCallReturnsString()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/js-time')
+                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js-time');
+
+            $this->assertStringContainsString('2021', $browser->text('#js-fn'));
+
+            $browser->travelBack();
+        });
+    }
+
+    /**
+     * Asserts a parseable time string is within tolerance of the expected time.
+     *
+     * The JavaScript clock ticks forward from the traveled instant, so
+     * assertions allow for page age and CI slowness.
+     *
+     * @param   Carbon  $expected  The expected time
+     * @param   string  $actual    The time string extracted from the page
+     * @param   int     $seconds   The allowed difference in seconds
+     *
+     * @return  void
+     */
+    protected function assertCarbonWithin(Carbon $expected, $actual, $seconds = 15)
+    {
+        $difference = abs(Carbon::parse($actual)->getTimestamp() - $expected->getTimestamp());
+
+        $this->assertLessThan(
+            $seconds,
+            $difference,
+            "Expected [{$actual}] to be within {$seconds} seconds of [{$expected->toIso8601String()}]."
+        );
+    }
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -58,5 +58,30 @@ abstract class DuskTestCase extends BaseTestCase
                 return Carbon::now()->startOfHour()->toIso8601String();
             },
         ]);
+
+        $router->get('js-time', [
+            'middleware' => 'web',
+            'uses' => function () {
+                // The inline script runs at document parse time, before any
+                // post-load injection could execute, so these values prove
+                // the Page.addScriptToEvaluateOnNewDocument path.
+                return '
+                <html>
+                    <body>
+                        <div id="js-iso"></div>
+                        <div id="js-now"></div>
+                        <div id="js-fn"></div>
+                        <div id="js-explicit"></div>
+                        <script>
+                            document.getElementById("js-iso").textContent = new Date().toISOString();
+                            document.getElementById("js-now").textContent = String(Date.now());
+                            document.getElementById("js-fn").textContent = Date();
+                            document.getElementById("js-explicit").textContent = new Date(2020, 0, 1, 12).toISOString();
+                        </script>
+                        <div id="server-time">' . Carbon::now()->toIso8601String() . '</div>
+                    </body>
+                </html>';
+            },
+        ]);
     }
 }


### PR DESCRIPTION
The package currently fakes only **server-side** time: `travelTo()` sets a `dusk-skip-time` cookie, and middleware calls `Carbon::setTestNow()` per request.

Despite the package name, the browser's JavaScript `Date` is untouched - any client-side code rendering clocks, timestamps, or date logic sees real time. This PR closes that gap: after using `travelTo($time)` ... calling `new Date()`, `Date.now()`, and `Date()` in the page should also return the traveled time; `travelBack()` restores real time.

I have previously worked around this in my own applications, but this is an attempt to pull that functionality into the package instead so that it is a more complete solution.

## Known limitations

- Likely to only work for the Chrome driver
- Web Workers and `performance.now()` are not faked