### PR TITLE
Add support for API (and other middleware groups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,36 @@ Limitations:
 - Only the zero-argument functions are shifted. Explicit constructions like `new Date(2020, 0, 1)`, `Date.parse()` and `Date.UTC()` behave natively (as you'd expect).
 - `performance.now()` and Web Workers are not faked.
 
+## Registering the `ModifyDuskBrowserTime` middleware
+
+By default, the package registers its middleware globally, so every request your application's HTTP kernel handles is covered — `web`, `api`, any custom middleware group, and even routes that don't belong to any group at all.
+
+The middleware is inert unless the browser has actually traveled through time (with `travelTo()`), so this is safe even if your application has no `api` route group, or doesn't use one at all.
+
+If you'd like more control, publish the config file:
+
+```bash
+php artisan vendor:publish --tag=dusk-time-travel-config
+```
+
+This creates `config/dusk-time-travel.php`:
+
+```php
+return [
+    'middleware' => true,
+];
+```
+
+The `middleware` option accepts:
+
+- `true` (default) — register globally, as described above.
+- `false` — don't register the middleware anywhere automatically. Use this if you'd rather wire it up yourself.
+- an array of middleware group names, e.g. `['web']` — register only on those groups instead of globally. Group names that you define but don't actually exist will be silently skipped.
+
+**Note on Laravel 7.x:** Defining an array of middleware group names is only supported on Laravel 8 onwards. If an array is defined in the config file on Laravel 7, it will instead be silently handled as if you'd set it to boolean true instead and the middleware will be registered globally.
+
 ## Testing
+
 A test case is included in this respository, but since it's a Dusk extension the tests are run on a Laravel instance having Dusk installed. You can test the plugin the same way the `.github/workflows/run-tests.yml` workflow does.
 
 ## Security Vulnerabilities

--- a/config/dusk-time-travel.php
+++ b/config/dusk-time-travel.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+     |--------------------------------------------------------------------------
+     | ModifyDuskBrowserTime middleware registration
+     |--------------------------------------------------------------------------
+     |
+     | Controls where \Paksuco\DuskTimeTravel\Middleware\ModifyDuskBrowserTime
+     | is registered. The middleware is inert unless the browser has used the
+     | `travelTo()` function, so registering it is usually safe.
+     |
+     | For available options, see `README.md`
+     |
+     */
+
+    'middleware' => true,
+
+];

--- a/src/DuskTimeTravelServiceProvider.php
+++ b/src/DuskTimeTravelServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace Paksuco\DuskTimeTravel;
 
-use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Paksuco\DuskTimeTravel\Middleware\ModifyDuskBrowserTime;
@@ -12,8 +13,54 @@ class DuskTimeTravelServiceProvider extends ServiceProvider
     /**
      * @return void
      */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/dusk-time-travel.php', 'dusk-time-travel');
+    }
+
+    /**
+     * @return void
+     */
     public function boot(Router $router, Kernel $kernel)
     {
-        $router->prependMiddlewareToGroup("web", ModifyDuskBrowserTime::class);
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/dusk-time-travel.php' => $this->app->configPath('dusk-time-travel.php'),
+            ], 'dusk-time-travel-config');
+        }
+
+        $middleware = config('dusk-time-travel.middleware', true);
+
+        // Do not register middleware
+        if ($middleware === false) {
+            return;
+        }
+
+        // We require this function, which was added in Laravel 8
+        // This means we can't do selective routing groups using an array
+        // Fall back safely to the default if it is not found
+        if (! method_exists($router, 'hasMiddlewareGroup')) {
+            $middleware = true;
+        }
+
+        // Register middleware globally (all groups)
+        if ($middleware === true) {
+            // prependMiddleware() is declared on the concrete Foundation kernel,
+            // not the Contracts kernel, so narrow the type before calling it.
+            // We do this to keep Psalm happy.
+            if ($kernel instanceof HttpKernel) {
+                $kernel->prependMiddleware(ModifyDuskBrowserTime::class);
+            }
+
+            return;
+        }
+
+        // Register middleware selectively (only for the specified groups)
+        foreach ((array) $middleware as $group) {
+            // If the named group does not exist, we silently skip it
+            if ($router->hasMiddlewareGroup($group)) {
+                $router->prependMiddlewareToGroup($group, ModifyDuskBrowserTime::class);
+            }
+        }
     }
 }

--- a/tests/Browser/BrowserTimeTest.php
+++ b/tests/Browser/BrowserTimeTest.php
@@ -16,8 +16,8 @@ class BrowserTimeTest extends DuskTestCase
             // travelTo() sets a cookie, which the browser only accepts while a
             // page of the app is open — a fresh session starts on about:blank,
             // so every test visits a page before its first travelTo().
-            $browser->visit('/js-time')
-                ->travelTo($target)->visit('/js-time');
+            $browser->visit('/js/time')
+                ->travelTo($target)->visit('/js/time');
 
             $this->assertCarbonWithin($target, $browser->text('#js-iso'));
 
@@ -33,8 +33,8 @@ class BrowserTimeTest extends DuskTestCase
         $target = Carbon::parse('2021-03-04 05:06:07');
 
         $this->browse(function (Browser $browser) use ($target) {
-            $browser->visit('/js-time')
-                ->travelTo($target)->visit('/js-time');
+            $browser->visit('/js/time')
+                ->travelTo($target)->visit('/js/time');
 
             $serverTime = Carbon::parse($browser->text('#server-time'));
             $this->assertCarbonWithin($serverTime, $browser->text('#js-iso'));
@@ -46,8 +46,8 @@ class BrowserTimeTest extends DuskTestCase
     public function testExplicitDateArgumentsUnaffected()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit('/js-time')
-                ->travelTo(Carbon::parse('2031-06-07 08:09:10'))->visit('/js-time');
+            $browser->visit('/js/time')
+                ->travelTo(Carbon::parse('2031-06-07 08:09:10'))->visit('/js/time');
 
             $this->assertStringContainsString('2020-01-0', $browser->text('#js-explicit'));
 
@@ -63,14 +63,14 @@ class BrowserTimeTest extends DuskTestCase
         $target = Carbon::parse('2021-03-04 05:06:07');
 
         $this->browse(function (Browser $browser) use ($target) {
-            $browser->visit('/js-time')->travelTo($target);
+            $browser->visit('/js/time')->travelTo($target);
 
             // The current page is unaffected, consistent with server-side time.
             $jsNowSeconds = (int) round(((float) $browser->script('return Date.now();')[0]) / 1000);
             $this->assertLessThan(15, abs($jsNowSeconds - Carbon::now()->getTimestamp()));
 
             // The next page load uses the traveled time.
-            $browser->visit('/js-time');
+            $browser->visit('/js/time');
             $this->assertCarbonWithin($target, $browser->text('#js-iso'));
 
             $browser->travelBack();
@@ -80,10 +80,10 @@ class BrowserTimeTest extends DuskTestCase
     public function testTravelBackRestoresBrowserTime()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit('/js-time')
-                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js-time');
+            $browser->visit('/js/time')
+                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js/time');
 
-            $browser->travelBack()->visit('/js-time');
+            $browser->travelBack()->visit('/js/time');
 
             $this->assertCarbonWithin(Carbon::now(), $browser->text('#js-iso'));
             $this->assertSame('undefined', $browser->script('return typeof window.__duskTimeTravel;')[0]);
@@ -93,12 +93,38 @@ class BrowserTimeTest extends DuskTestCase
     public function testDateFunctionCallReturnsString()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit('/js-time')
-                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js-time');
+            $browser->visit('/js/time')
+                ->travelTo(Carbon::parse('2021-03-04 05:06:07'))->visit('/js/time');
 
             $this->assertStringContainsString('2021', $browser->text('#js-fn'));
 
             $browser->travelBack();
+        });
+    }
+
+    public function testApiRouteSeesRealTimeByDefault()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit("/api/time")
+                ->assertSee(Carbon::now()->startOfHour()->toIso8601String());
+        });
+    }
+
+    public function testApiRouteSeesTraveledTime()
+    {
+        $this->browse(function (Browser $browser) {
+            // The cookie is only accepted while a page of the app is open,
+            // so visit something first before traveling — same requirement
+            // as the "web" group.
+            $browser->visit("/api/time")
+                ->travelTo(Carbon::yesterday()->setHour(4))
+                ->visit("/api/time")
+                ->assertSee(Carbon::yesterday()->setHour(4)->startOfHour()->toIso8601String());
+
+            $browser->travelBack()
+                ->visit("/api/time")
+                ->assertSee(Carbon::now()->startOfHour()->toIso8601String());
         });
     }
 

--- a/tests/Browser/DuskTimeTravelDisabledConfigTest.php
+++ b/tests/Browser/DuskTimeTravelDisabledConfigTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Paksuco\DuskTimeTravel\Tests\Browser;
+
+use Illuminate\Support\Carbon;
+use Paksuco\DuskTimeTravel\DuskTimeTravelServiceProvider;
+use Paksuco\DuskTimeTravel\Tests\DuskTestCase;
+
+class DuskTimeTravelDisabledConfigTest extends DuskTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            DuskTimeTravelServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('dusk-time-travel.middleware', false);
+    }
+
+    public function testFalseConfigDisablesTimeTravelEntirely()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this
+            ->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/web/time');
+
+        $response->assertDontSee($target->toIso8601String());
+    }
+}

--- a/tests/Browser/DuskTimeTravelEnabledConfigTest.php
+++ b/tests/Browser/DuskTimeTravelEnabledConfigTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Paksuco\DuskTimeTravel\Tests\Browser;
+
+use Illuminate\Support\Carbon;
+use Paksuco\DuskTimeTravel\DuskTimeTravelServiceProvider;
+use Paksuco\DuskTimeTravel\Tests\DuskTestCase;
+
+class DuskTimeTravelEnabledConfigTest extends DuskTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            DuskTimeTravelServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('dusk-time-travel.middleware', true);
+    }
+
+    public function testTrueConfigWorksOnWebRoutes()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/web/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+
+    public function testTrueConfigWorksOnApiRoutes()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/api/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+
+    public function testTrueConfigWorksOnJsRoutes()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/js/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+
+    public function testTrueConfigWorksOnUngroupedRoutes()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/ungrouped/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+
+    /**
+     * Applications without an "api" route group (e.g. a fresh Laravel 11+
+     * skeleton that never ran `php artisan install:api`) are unaffected by
+     * default: the global registration doesn't need that group to exist,
+     * so nothing breaks and nothing needs to be configured.
+     */
+    public function testTrueConfigDoesNotRequireApiRouteToExist()
+    {
+        $router = $this->app['router'];
+
+        if (! method_exists($router, 'hasMiddlewareGroup') || ! method_exists($router, 'flushMiddlewareGroups')) {
+            // Router::hasMiddlewareGroup()/flushMiddlewareGroups() requires Laravel 8+
+            $this->markTestSkipped('This test is skipped in Laravel 7.x');
+        }
+
+        $this->assertTrue($router->hasMiddlewareGroup('api'));
+
+        // Simulate an application that never registered one at all.
+        $router->flushMiddlewareGroups();
+        $router->middlewareGroup('web', []);
+
+        $this->assertFalse($router->hasMiddlewareGroup('api'));
+
+        $target = Carbon::parse('2040-10-20 16:00:00');
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/ungrouped/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+}

--- a/tests/Browser/DuskTimeTravelRestrictedConfigTest.php
+++ b/tests/Browser/DuskTimeTravelRestrictedConfigTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Paksuco\DuskTimeTravel\Tests\Browser;
+
+use Illuminate\Support\Carbon;
+use Paksuco\DuskTimeTravel\DuskTimeTravelServiceProvider;
+use Paksuco\DuskTimeTravel\Tests\DuskTestCase;
+
+class DuskTimeTravelRestrictedConfigTest extends DuskTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            DuskTimeTravelServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('dusk-time-travel.middleware', ['web']);
+    }
+
+    public function testRestrictingToWebStillTravelsTimeOnWeb()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/web/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+
+    public function testRestrictingToWebLeavesApiUntouched()
+    {
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/api/time');
+
+        $response->assertDontSee($target->toIso8601String());
+    }
+
+    /**
+     * A typo'd or nonexistent group name in configuration must not break
+     * the application — it must be silently skipped.
+     */
+    public function testRestrictingToWebSkipsNonExistingGroupNames()
+    {
+        $app = $this->app;
+        $app['config']->set('dusk-time-travel.middleware', ['web', 'does-not-exist']);
+
+        (new DuskTimeTravelServiceProvider($app))->boot(
+            $app['router'],
+            $app->make(\Illuminate\Contracts\Http\Kernel::class)
+        );
+
+        $target = Carbon::parse('2040-10-20 16:00:00');
+
+        $response = $this->withUnencryptedCookie('dusk-skip-time', $target->toIso8601String())
+            ->get('/web/time');
+
+        $response->assertSee($target->toIso8601String());
+    }
+}

--- a/tests/Browser/ExtensionTest.php
+++ b/tests/Browser/ExtensionTest.php
@@ -13,7 +13,7 @@ class ExtensionTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser
-                ->visit("/time")
+                ->visit("/web/time")
                 ->screenshot("check_route")
                 ->assertSee(Carbon::now()->startOfHour()->toIso8601String());
         });
@@ -24,7 +24,7 @@ class ExtensionTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->travelTo(Carbon::yesterday()->setHour(4))
-                ->visit("/time")
+                ->visit("/web/time")
                 ->assertSee(Carbon::yesterday()->setHour(4)->startOfHour()->toIso8601String());
         });
     }
@@ -33,11 +33,11 @@ class ExtensionTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->travelTo(Carbon::yesterday()->setHour(4))
-                ->visit("/time")
+                ->visit("/web/time")
                 ->assertSee(Carbon::yesterday()->setHour(4)->startOfHour()->toIso8601String());
 
             $browser->travelBack()
-                ->visit("/time")
+                ->visit("/web/time")
                 ->assertSee(Carbon::now()->startOfHour()->toIso8601String());
         });
     }

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Carbon;
 use Orchestra\Testbench\Dusk\TestCase as BaseTestCase;
 use Paksuco\DuskTimeTravel\Browser as TimeTravelEnabledBrowser;
 use Paksuco\DuskTimeTravel\DuskTimeTravelServiceProvider;
-use Paksuco\DuskTimeTravel\Middleware\ModifyDuskBrowserTime;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -33,33 +32,28 @@ abstract class DuskTestCase extends BaseTestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $this->pushMiddleware();
-        $this->registerTestRoute($app);
+        $this->registerTestRoutes($app);
     }
 
-    protected function pushMiddleware()
-    {
-        $kernel = $this->getKernel();
-        $kernel->pushMiddleware(ModifyDuskBrowserTime::class);
-    }
-
-    protected function getKernel()
-    {
-        return app('Illuminate\Contracts\Http\Kernel');
-    }
-
-    protected function registerTestRoute($app)
+    protected function registerTestRoutes($app)
     {
         $router = $app["router"];
 
-        $router->get('time', [
+        $router->get('web/time', [
             'middleware' => 'web',
             'uses' => function () {
                 return Carbon::now()->startOfHour()->toIso8601String();
             },
         ]);
 
-        $router->get('js-time', [
+        $router->get('api/time', [
+            'middleware' => 'api',
+            'uses' => function () {
+                return Carbon::now()->startOfHour()->toIso8601String();
+            },
+        ]);
+
+        $router->get('js/time', [
             'middleware' => 'web',
             'uses' => function () {
                 // The inline script runs at document parse time, before any
@@ -83,5 +77,10 @@ abstract class DuskTestCase extends BaseTestCase
                 </html>';
             },
         ]);
+
+        // Deliberately declared outside any middleware group, so the
+        // default (global) registration can be told apart from a
+        // group-based one: only global reaches this route.
+        $router->get('ungrouped/time', fn () => Carbon::now()->toIso8601String());
     }
 }


### PR DESCRIPTION
Dusk Time Travel previously only supported routes on the `web` middleware group.

In v1.1.0, support for time travelling the front-end javascript `Date()` functions was added.

This PR adds support for other middleware groups, including the `api` middleware group. It also adds an optional configuration file that users can pull into their project to configure which groups the middleware will apply to.

## Registering the `ModifyDuskBrowserTime` middleware (if this PR is merged)

By default, the package registers its middleware globally, so every request your application's HTTP kernel handles is covered — `web`, `api`, any custom middleware group, and even routes that don't belong to any group at all.

The middleware is inert unless the browser has actually traveled through time (with `travelTo()`), so this is safe even if your application has no `api` route group, or doesn't use one at all.

If you'd like more control, publish the config file:

```bash
php artisan vendor:publish --tag=dusk-time-travel-config
```

This creates `config/dusk-time-travel.php`:

```php
return [
    'middleware' => true,
];
```

The `middleware` option accepts:

- `true` (default) — register globally, as described above.
- `false` — don't register the middleware anywhere automatically. Use this if you'd rather wire it up yourself.
- an array of middleware group names, e.g. `['web']` — register only on those groups instead of globally. Group names that you define but don't actually exist will be silently skipped.

**Note on Laravel 7.x:** Defining an array of middleware group names is only supported on Laravel 8 onwards. If an array is defined in the config file on Laravel 7, it will instead be silently handled as if you'd set it to boolean true instead and the middleware will be registered globally.